### PR TITLE
PR: Fix when all neighbors data are null

### DIFF
--- a/cdprep/gapfill_data/gapfill_weather_algorithm.py
+++ b/cdprep/gapfill_data/gapfill_weather_algorithm.py
@@ -376,7 +376,10 @@ class DataGapfiller(QObject):
         return gapfilled_data
 
     def build_mlr_model(self, X, Y):
-
+        """
+        Build a multiple linear model using the provided independent (X) and
+        dependent (y) variable data.
+        """
         if self.regression_mode == 1:  # Ordinary Least Square regression
 
             # http://statsmodels.sourceforge.net/devel/generated/
@@ -388,7 +391,6 @@ class DataGapfiller(QObject):
 
             # Using Numpy function:
             A = np.linalg.lstsq(X, Y, rcond=None)[0]
-
         else:  # Least Absolute Deviations regression
 
             # http://statsmodels.sourceforge.net/devel/generated/

--- a/cdprep/gapfill_data/gapfill_weather_algorithm.py
+++ b/cdprep/gapfill_data/gapfill_weather_algorithm.py
@@ -206,12 +206,12 @@ class DataGapfiller(QObject):
                 gapfill_date_range, neighbors].notnull()
             notnull_groups = notnull.groupby(by=neighbors, axis=0)
             for group in notnull_groups:
-                if len(group[1].columns) == 0:
+                group_dates = group[1].index
+                group_neighbors = group[1].columns[list(group[0])]
+                if len(group_neighbors) == 0:
                     # It is impossible to fill the data in this group
                     # because all neighboring stations are empty.
                     continue
-                group_dates = group[1].index
-                group_neighbors = group[1].columns[list(group[0])]
 
                 # Determines the neighboring stations to include in the
                 # regression model.


### PR DESCRIPTION
This PR fix a bug that occurs when filling the gaps for dates where all neighboring stations had null data.

```python
Gapfilling data for variable Ptot...
9843
Traceback (most recent call last):
  File "C:\Users\User\climate-data-preprocessing-tool\cdprep\gapfill_data\gapfill_weather_algorithm.py", line 263, in gapfill_data
    A = self.build_mlr_model(X, Y)
  File "C:\Users\User\climate-data-preprocessing-tool\cdprep\gapfill_data\gapfill_weather_algorithm.py", line 406, in build_mlr_model
    A = L1LinearRegression(X, Y)
  File "C:\Users\User\climate-data-preprocessing-tool\cdprep\gapfill_data\gapfill_weather_algorithm.py", line 990, in L1LinearRegression
    BOld[0] += 1e-5
IndexError: index 0 is out of bounds for axis 0 with size 0
```