### PR TITLE
PR: Pin numpy to the 1.16 series and pandas to the 0.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ qtawesome == 0.7.*
 xlsxwriter
 xlrd
 xlwt
-numpy>1.14
+numpy == 1.16.*
+pandas == 0.25.*
 requests
-pandas


### PR DESCRIPTION
There is an error that is happening if we use the latest versions with the PyInstaller binary.

```python
Starting Climate Data Preprocessing Tool...
 ** On entry to DGEBAL parameter number  3 had an illegal value
 ** On entry to DGEHRD  parameter number  2 had an illegal value
 ** On entry to DORGHR DORGQR parameter number  2 had an illegal value
 ** On entry to DHSEQR parameter number  4 had an illegal value
Traceback (most recent call last):
  File "cdprep\app\mainwindow.py", line 33, in <module>
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 623, in exec_module
  File "cdprep\dwnld_data\dwnld_data_manager.py", line 21, in <module>
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "c:\hostedtoolcache\windows\python\3.7.9\x64\lib\site-packages\PyInstaller\loader\pyimod03_importers.py", line 623, in exec_module
  File "site-packages\numpy\__init__.py", line 305, in <module>
  File "site-packages\numpy\__init__.py", line 302, in _win_os_check
RuntimeError: The current Numpy installation ('D:\\Downloads\\cdprep_0.1.1_win_amd64\\Climate Data Preprocessing Tool\\numpy\\__init__.pyc') fails to pass a sanity check due to a bug in the windows runtime. See this issue for more information: https://tinyurl.com/y3dm3h86
[4860] Failed to execute script mainwindow
```

