### PR TITLE
PR: Fix stop download process

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -6,3 +6,4 @@ scanner:
 pycodestyle:
     ignore:  # Errors and warnings to ignore
         - E402  # module level import not at top of file
+        - W504  # line break after binary operator

--- a/cdprep/dwnld_data/dwnld_data_manager.py
+++ b/cdprep/dwnld_data/dwnld_data_manager.py
@@ -521,6 +521,7 @@ class WeatherStationDownloader(QWidget):
         self.progressbar.show()
         self.btn_download.setIcon(get_icon('stop'))
         self.left_panel.setEnabled(False)
+        self.station_table.setEnabled(False)
 
         # Set thread working directory.
         self.dwnld_worker.dirname = self.workdir
@@ -536,6 +537,7 @@ class WeatherStationDownloader(QWidget):
         self.wait_for_thread_to_quit()
         self.btn_download.setEnabled(True)
         self.left_panel.setEnabled(True)
+        self.station_table.setEnabled(True)
         self._dwnld_inprogress = False
         self.sig_download_process_ended.emit()
         print('Download process stopped.')
@@ -549,6 +551,7 @@ class WeatherStationDownloader(QWidget):
             print('Raw weather data downloaded for all selected stations.')
             self.progressbar.hide()
             self.left_panel.setEnabled(True)
+            self.station_table.setEnabled(True)
             self._dwnld_inprogress = False
             self.sig_download_process_ended.emit()
             return

--- a/cdprep/dwnld_data/dwnld_data_manager.py
+++ b/cdprep/dwnld_data/dwnld_data_manager.py
@@ -519,7 +519,7 @@ class WeatherStationDownloader(QWidget):
 
         # Update the UI.
         self.progressbar.show()
-        self.btn_download.setIcon(get_icon('stop'))
+        self.btn_download.setText("Cancel")
         self.left_panel.setEnabled(False)
         self.station_table.setEnabled(False)
 
@@ -531,11 +531,12 @@ class WeatherStationDownloader(QWidget):
         self.download_next_station()
 
     def stop_download_process(self):
+        """Stop the downloading process."""
         print('Stopping the download process...')
-        self.btn_download.setIcon(get_icon('download'))
         self.dwnld_worker.stop_download()
         self.wait_for_thread_to_quit()
         self.btn_download.setEnabled(True)
+        self.btn_download.setText("Download")
         self.left_panel.setEnabled(True)
         self.station_table.setEnabled(True)
         self._dwnld_inprogress = False
@@ -549,6 +550,7 @@ class WeatherStationDownloader(QWidget):
         except IndexError:
             # There is no more data to download.
             print('Raw weather data downloaded for all selected stations.')
+            self.btn_download.setText("Download")
             self.progressbar.hide()
             self.left_panel.setEnabled(True)
             self.station_table.setEnabled(True)

--- a/cdprep/dwnld_data/dwnld_data_manager.py
+++ b/cdprep/dwnld_data/dwnld_data_manager.py
@@ -522,6 +522,7 @@ class WeatherStationDownloader(QWidget):
         self.btn_download.setText("Cancel")
         self.left_panel.setEnabled(False)
         self.station_table.setEnabled(False)
+        self.btn_fetch.setEnabled(False)
 
         # Set thread working directory.
         self.dwnld_worker.dirname = self.workdir
@@ -539,6 +540,8 @@ class WeatherStationDownloader(QWidget):
         self.btn_download.setText("Download")
         self.left_panel.setEnabled(True)
         self.station_table.setEnabled(True)
+        self.btn_fetch.setEnabled(True)
+
         self._dwnld_inprogress = False
         self.sig_download_process_ended.emit()
         print('Download process stopped.')
@@ -554,6 +557,7 @@ class WeatherStationDownloader(QWidget):
             self.progressbar.hide()
             self.left_panel.setEnabled(True)
             self.station_table.setEnabled(True)
+            self.btn_fetch.setEnabled(True)
             self._dwnld_inprogress = False
             self.sig_download_process_ended.emit()
             return

--- a/cdprep/dwnld_data/dwnld_data_manager.py
+++ b/cdprep/dwnld_data/dwnld_data_manager.py
@@ -542,7 +542,6 @@ class WeatherStationDownloader(QWidget):
         except IndexError:
             # There is no more data to download.
             print('Raw weather data downloaded for all selected stations.')
-            self.btn_download.setIcon(get_icon('download'))
             self.progressbar.hide()
             self.sig_download_process_ended.emit()
             return

--- a/cdprep/dwnld_data/dwnld_data_manager.py
+++ b/cdprep/dwnld_data/dwnld_data_manager.py
@@ -114,6 +114,7 @@ class WeatherStationDownloader(QWidget):
         self.__initUI__()
 
         # Setup the raw data downloader.
+        self._dwnld_inprogress = False
         self._dwnld_stations_list = []
         self.dwnld_thread = QThread()
         self.dwnld_worker = RawDataDownloader()
@@ -524,6 +525,7 @@ class WeatherStationDownloader(QWidget):
         self.dwnld_worker.dirname = self.workdir
 
         # Start downloading data.
+        self._dwnld_inprogress = True
         self.download_next_station()
 
     def stop_download_process(self):
@@ -532,6 +534,7 @@ class WeatherStationDownloader(QWidget):
         self.dwnld_worker.stop_download()
         self.wait_for_thread_to_quit()
         self.btn_download.setEnabled(True)
+        self._dwnld_inprogress = False
         self.sig_download_process_ended.emit()
         print('Download process stopped.')
 
@@ -543,6 +546,7 @@ class WeatherStationDownloader(QWidget):
             # There is no more data to download.
             print('Raw weather data downloaded for all selected stations.')
             self.progressbar.hide()
+            self._dwnld_inprogress = False
             self.sig_download_process_ended.emit()
             return
 

--- a/cdprep/dwnld_data/dwnld_data_manager.py
+++ b/cdprep/dwnld_data/dwnld_data_manager.py
@@ -716,7 +716,8 @@ class RawDataDownloader(QObject):
             if self.__stop_dwnld:
                 # Stop the downloading process.
                 self.__stop_dwnld = False
-                print("Downloading process for station %s stopped." % StaName)
+                print("Downloading process for station {} stopped.".format(
+                    StaName))
                 return
 
             # Define file and URL paths.

--- a/cdprep/dwnld_data/dwnld_data_manager.py
+++ b/cdprep/dwnld_data/dwnld_data_manager.py
@@ -295,8 +295,8 @@ class WeatherStationDownloader(QWidget):
         toolbar_grid.setContentsMargins(0, 10, 0, 0)
 
         # Setup the left panel.
-        left_panel = QFrame()
-        left_panel_grid = QGridLayout(left_panel)
+        self.left_panel = QFrame()
+        left_panel_grid = QGridLayout(self.left_panel)
         left_panel_grid.setContentsMargins(0, 0, 0, 0)
         left_panel_grid.addWidget(
             QLabel('Search Criteria'), 0, 0)
@@ -312,7 +312,7 @@ class WeatherStationDownloader(QWidget):
 
         # Create the main grid.
         main_layout = QGridLayout(self)
-        main_layout.addWidget(left_panel, 0, 0)
+        main_layout.addWidget(self.left_panel, 0, 0)
         main_layout.addWidget(self.station_table, 0, 1)
         main_layout.addWidget(self.waitspinnerbar, 0, 1)
         main_layout.addWidget(toolbar_widg, 1, 0, 1, 2)
@@ -520,6 +520,7 @@ class WeatherStationDownloader(QWidget):
         # Update the UI.
         self.progressbar.show()
         self.btn_download.setIcon(get_icon('stop'))
+        self.left_panel.setEnabled(False)
 
         # Set thread working directory.
         self.dwnld_worker.dirname = self.workdir
@@ -534,6 +535,7 @@ class WeatherStationDownloader(QWidget):
         self.dwnld_worker.stop_download()
         self.wait_for_thread_to_quit()
         self.btn_download.setEnabled(True)
+        self.left_panel.setEnabled(True)
         self._dwnld_inprogress = False
         self.sig_download_process_ended.emit()
         print('Download process stopped.')
@@ -546,6 +548,7 @@ class WeatherStationDownloader(QWidget):
             # There is no more data to download.
             print('Raw weather data downloaded for all selected stations.')
             self.progressbar.hide()
+            self.left_panel.setEnabled(True)
             self._dwnld_inprogress = False
             self.sig_download_process_ended.emit()
             return

--- a/cdprep/dwnld_data/tests/test_dwnld_raw_data.py
+++ b/cdprep/dwnld_data/tests/test_dwnld_raw_data.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © Climate Data Preprocessing Tool Project Contributors
+# https://github.com/cgq-qgc/climate-data-preprocessing-tool
+#
+# This file is part of Climate Data Preprocessing Tool.
+# Licensed under the terms of the GNU General Public License.
+# -----------------------------------------------------------------------------
+
+"""
+Tests for the RawDataDownloader.
+"""
+
+# ---- Standard imports
+import os
+import os.path as osp
+os.environ['CDPREP_PYTEST'] = 'True'
+
+# ---- Third party imports
+import pytest
+
+# ---- Local imports
+from cdprep.dwnld_data.dwnld_data_manager import (
+    RawDataDownloader, read_raw_datafile)
+
+
+# =============================================================================
+# ---- Fixtures
+# =============================================================================
+@pytest.fixture(scope='module')
+def workdir(tmp_path_factory):
+    """A fixture for a test working directory."""
+    workdir = osp.join(
+        tmp_path_factory.getbasetemp(), "@ tèst-fïl! 'dätèt!")
+    os.makedirs(workdir, exist_ok=True)
+    return workdir
+
+
+@pytest.fixture()
+def dwnld_worker(qtbot, mocker, workdir):
+    """A fixture for the WeatherDataGapfiller."""
+    dwnld_worker = RawDataDownloader()
+    return dwnld_worker
+
+
+# =============================================================================
+# ---- Tests for the RawDataDownloader
+# =============================================================================
+def test_download_raw_data(dwnld_worker, workdir, qtbot):
+    """
+    Test that downloading raw datafiles from the Environnement Canada server
+    is working as expected.
+    """
+    dwnld_worker = RawDataDownloader()
+
+    # Set attributes of the data downloader.
+    dwnld_worker.dirname = workdir
+    dwnld_worker.StaName = "MARIEVILLE"
+    dwnld_worker.stationID = "5406"
+    dwnld_worker.yr_start = 2010
+    dwnld_worker.yr_end = 2010
+    dwnld_worker.climateID = "7024627"
+
+    expected_filename = osp.join(
+        workdir, 'RAW', "MARIEVILLE (7024627)",
+        "eng-daily-01012010-12312010.csv")
+
+    # Assert that the logic to stop the download process is working as
+    # expected.
+    assert not osp.exists(expected_filename)
+    dwnld_worker.stop_download()
+    dwnld_worker.download_data()
+    assert not osp.exists(expected_filename)
+
+    # Download data for station Marieville
+    with qtbot.waitSignal(dwnld_worker.sig_download_finished):
+        dwnld_worker.download_data()
+    assert osp.exists(expected_filename)
+
+    # Download the raw data file again to test the case when the raw data
+    # file already exists in the 'RAW' folder.
+    dwnld_worker.download_data()
+
+
+def test_read_raw_datafile(workdir):
+    """
+    Read the weather data from raw data file that was just downloaded in the
+    previous test.
+    """
+    rawdata_filename = osp.join(
+        workdir, 'RAW', "MARIEVILLE (7024627)",
+        "eng-daily-01012010-12312010.csv")
+    dataset = read_raw_datafile(rawdata_filename)
+    assert len(dataset) == 365
+    assert (dataset.columns.values.tolist() ==
+            ['Year', 'Month', 'Day', 'Max Temp (°C)',
+             'Min Temp (°C)', 'Mean Temp (°C)', 'Total Precip (mm)'])
+    assert (dataset.iloc[0].values.tolist() ==
+            ['2010', '01', '01', '-3.0', '-6.0', '-4.5', '3.0'])
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', __file__, '-v', '-rw'])

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+codecov:
+  branch: master
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch: no
+    changes: no
+    
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+   
+comment: false


### PR DESCRIPTION
This PR fix the option to cancel the weather datafile download process. Clicking on the `Stop` button does currently nothing in the current version.

![stop_download](https://user-images.githubusercontent.com/10170372/98023309-b7de3f00-1dd4-11eb-8789-3688f09d3e23.gif)