### PR TITLE
PR: cache data once it is loaded from the working directory

### DIFF
--- a/cdprep/gapfill_data/gapfill_weather_algorithm.py
+++ b/cdprep/gapfill_data/gapfill_weather_algorithm.py
@@ -83,9 +83,13 @@ class DataGapfillManager(TaskManagerBase):
         if not postpone_exec:
             self.run_tasks()
 
-    def load_data(self, callback=None, postpone_exec=False):
+    def load_data(self, force_reload=False, callback=None,
+                  postpone_exec=False):
         """Read the csv files in the input data directory folder."""
-        self.add_task('load_data', callback=callback)
+        self.add_task(
+            'load_data',
+            force_reload=force_reload,
+            callback=callback)
         if not postpone_exec:
             self.run_tasks()
 
@@ -136,6 +140,8 @@ class DataGapfillWorker(WorkerBase):
 
         self.WEATHER = self.wxdatasets = WeatherData()
         self.wxdatasets.sig_task_progress.connect(self.sig_task_progress.emit)
+        self.wxdatasets.sig_status_message.connect(
+            self.sig_status_message.emit)
 
         self.inputDir = None
         self.isParamsValid = False
@@ -175,17 +181,71 @@ class DataGapfillWorker(WorkerBase):
                              ' with a value greater than 0.')
         self.__NSTAmax = x
 
-    def load_data(self):
+    def load_data(self, force_reload=False):
         """
         Read the csv files in the input data directory folder.
+
+        The resulting formatted dataset is saved in a structured numpy array
+        in binary format, so that loading time is improved on subsequent runs.
+        Some checks are made to be sure the binary match with the current
+        data files in the folder.
         """
-        if not self.inputDir:
+        self.target = None
+        self.alt_and_dist = None
+        self.corcoef = None
+
+        if self.inputDir is None:
             print('Please specify a valid input data file directory.')
             return
         if not osp.exists(self.inputDir):
-            print('Data Directory path does not exists.')
+            print('Input data directory does not exists.')
             return
+        if force_reload is True:
+            print('Force reloading data from csv file...')
+            return self._reload_data()
 
+        # Check if a cached binary file exists.
+        binfile = os.path.join(self.inputDir, '__cache__', 'fdata.npy')
+        if not osp.exists(binfile):
+            return self._reload_data()
+
+        # Try to load data from the cached binary file.
+        try:
+            self.wxdatasets.load_from_binary(self.inputDir)
+        except Exception as e:
+            print('Failed to load data from cache because '
+                  'of the following error:')
+            print(e)
+            return self._reload_data()
+        else:
+            # Scan input folder for changes
+
+            # If one of the csv data file contained within the input data
+            # directory has changed since last time the binary file was
+            # created, the data will be reloaded from the csv files and a
+            # new binary file will be generated.
+
+            filenames = [osp.basename(f) for f in self.wxdatasets.filenames]
+            bmtime = osp.getmtime(binfile)
+            count = 0
+            for f in os.listdir(self.inputDir):
+                if f.endswith('.csv'):
+                    fmtime = osp.getmtime(osp.join(self.inputDir, f))
+                    if f in filenames and fmtime <= bmtime:
+                        count += 1
+            if len(filenames) != count:
+                print('One or more input data files in the workind '
+                      'directory changed since the last time the data '
+                      'were cached.')
+                return self._reload_data()
+            else:
+                print('Data loaded from cache.')
+
+    def _reload_data(self):
+        """
+        Read the csv files in the input data directory folder, format
+        the datasets and save the results in a binary file.
+        """
         filepaths = [
             osp.join(self.inputDir, f) for
             f in os.listdir(self.inputDir) if f.endswith('.csv')]
@@ -195,10 +255,10 @@ class DataGapfillWorker(WorkerBase):
         message = 'Reading data from csv files...'
         print(message)
         self.sig_status_message.emit(message)
-        self.target = None
-        self.alt_and_dist = None
-        self.corcoef = None
+
         self.wxdatasets.load_and_format_data(filepaths)
+        self.wxdatasets.save_to_binary(self.inputDir)
+
         print('Data loaded successfully.')
         self.sig_status_message.emit('')
 
@@ -766,21 +826,23 @@ class WeatherData(QObject):
     *GapFillWeather* class.
     """
     sig_task_progress = QSignal(int)
+    sig_status_message = QSignal(str)
 
     def __init__(self):
         super().__init__()
 
         self.data = None
         self.metadata = None
-        self.fnames = []
 
     @property
     def filenames(self):
         """
         Return the list of file paths from which data were loaded.
         """
-        return (self.metadata['filename'].tolist() if
-                self.metadata is not None else [])
+        if self.metadata is None or self.metadata.empty:
+            return []
+        else:
+            return self.metadata['filename'].tolist()
 
     @property
     def station_names(self):
@@ -813,6 +875,7 @@ class WeatherData(QObject):
         """
         return len(self.station_ids)
 
+    # ---- Load and format data.
     def load_and_format_data(self, paths):
         """
         Parameters
@@ -820,7 +883,7 @@ class WeatherData(QObject):
         paths: list
             A list of absolute paths containing daily weater data files
         """
-        self.fnames = [osp.basename(path) for path in paths]
+        self.sig_status_message.emit('Reading data from csv files... 0%')
         self.data = {var: pd.DataFrame([]) for var in VARNAMES}
         self.metadata = pd.DataFrame([])
         if len(paths) == 0:
@@ -850,13 +913,19 @@ class WeatherData(QObject):
 
                 # Append the data of this station to that of the others.
                 for name in VARNAMES:
-                    self.data[name] = self.data[name].merge(
+                    self.data[name] = self.data[name].join(
+                        sta_data[[name]].rename(columns={name: sta_id}),
+                        how='outer')
+                    self.data[name] = self.data[name].join(
                         sta_data[[name]].rename(columns={name: sta_id}),
                         left_index=True,
                         right_index=True,
                         how='outer')
-            self.sig_task_progress.emit(int(
-                i / len(paths) * 100))
+            percent_progress = int(i / len(paths) * 100)
+            self.sig_task_progress.emit(percent_progress)
+            self.sig_status_message.emit(
+                'Reading data from csv files... {:d}%'.format(
+                    percent_progress))
 
         # Make the daily time series continuous.
         for name in VARNAMES:

--- a/cdprep/gapfill_data/gapfill_weather_algorithm.py
+++ b/cdprep/gapfill_data/gapfill_weather_algorithm.py
@@ -883,12 +883,12 @@ class WeatherData(QObject):
         paths: list
             A list of absolute paths containing daily weater data files
         """
-        self.sig_status_message.emit('Reading data from csv files... 0%')
         self.data = {var: pd.DataFrame([]) for var in VARNAMES}
         self.metadata = pd.DataFrame([])
         if len(paths) == 0:
             return
 
+        self.sig_status_message.emit('Reading data from csv files... 0%')
         for i, path in enumerate(paths):
             try:
                 sta_metadata, sta_data = read_weather_datafile(path)

--- a/cdprep/gapfill_data/gapfill_weather_algorithm.py
+++ b/cdprep/gapfill_data/gapfill_weather_algorithm.py
@@ -31,9 +31,7 @@ from cdprep.config.gui import RED, LIGHTGRAY
 from cdprep.gapfill_data.read_weather_data import read_weather_datafile
 from cdprep import __namever__
 
-PRECIP_VARIABLES = ['Ptot']
-TEMP_VARIABLES = ['Tmax', 'Tavg', 'Tmin']
-VARNAMES = PRECIP_VARIABLES + TEMP_VARIABLES
+VARNAMES = ['Ptot', 'Tmax', 'Tavg', 'Tmin']
 
 
 class DataGapfillManager(TaskManagerBase):

--- a/cdprep/gapfill_data/gapfill_weather_algorithm.py
+++ b/cdprep/gapfill_data/gapfill_weather_algorithm.py
@@ -913,10 +913,7 @@ class WeatherData(QObject):
 
                 # Append the data of this station to that of the others.
                 for name in VARNAMES:
-                    self.data[name] = self.data[name].join(
-                        sta_data[[name]].rename(columns={name: sta_id}),
-                        how='outer')
-                    self.data[name] = self.data[name].join(
+                    self.data[name] = self.data[name].merge(
                         sta_data[[name]].rename(columns={name: sta_id}),
                         left_index=True,
                         right_index=True,

--- a/cdprep/gapfill_data/gapfill_weather_algorithm.py
+++ b/cdprep/gapfill_data/gapfill_weather_algorithm.py
@@ -239,9 +239,6 @@ class DataGapfillWorker(WorkerBase):
                   "for target station {}.".format(station_name))
             self.sig_status_message.emit('')
 
-    def read_summary(self):
-        return self.WEATHER.read_summary(self.outputdir)
-
     def get_valid_neighboring_stations(self, hdist_limit, vdist_limit):
         """
         Return the list of neighboring stations that are within the

--- a/cdprep/gapfill_data/gapfill_weather_algorithm.py
+++ b/cdprep/gapfill_data/gapfill_weather_algorithm.py
@@ -865,6 +865,21 @@ class WeatherData(QObject):
         # Set the index of the metadata.
         self.metadata = self.metadata.set_index('Station ID', drop=True)
 
+    def load_from_binary(self, dirname):
+        """Load the data and metadata from binary files."""
+        A = np.load(
+            osp.join(dirname, '__cache__', 'fdata.npy'),
+            allow_pickle=True
+            ).item()
+        self.data = A['data']
+        self.metadata = A['metadata']
+
+    def save_to_binary(self, dirname):
+        """Save the data and metadata to binary files."""
+        os.makedirs(osp.join(dirname, '__cache__'), exist_ok=True)
+        A = {'data': self.data, 'metadata': self.metadata}
+        np.save(osp.join(dirname, '__cache__', 'fdata.npy'), A)
+
     # ---- Utilities
     def alt_and_dist_calc(self, target_station_id):
         """

--- a/cdprep/gapfill_data/gapfill_weather_gui.py
+++ b/cdprep/gapfill_data/gapfill_weather_gui.py
@@ -396,7 +396,9 @@ class WeatherDataGapfiller(QMainWindow):
         station_names = self.gapfill_manager.get_station_names()
         station_ids = self.gapfill_manager.get_station_ids()
         for station_name, station_id in zip(station_names, station_ids):
-            self.target_station.addItem(station_name, userData=station_id)
+            self.target_station.addItem(
+                '{} ({})'.format(station_name, station_id),
+                userData=station_id)
         self.target_station.blockSignals(False)
 
         self.sta_display_summary.setHtml(

--- a/cdprep/gapfill_data/gapfill_weather_gui.py
+++ b/cdprep/gapfill_data/gapfill_weather_gui.py
@@ -390,8 +390,6 @@ class WeatherDataGapfiller(QMainWindow):
         """
         self.left_panel.setEnabled(True)
         self.right_panel.setEnabled(True)
-        self.progressbar.hide()
-        self.progressbar.setValue(0)
 
         self.target_station.blockSignals(True)
         station_names = self.gapfill_manager.get_station_names()

--- a/cdprep/gapfill_data/gapfill_weather_gui.py
+++ b/cdprep/gapfill_data/gapfill_weather_gui.py
@@ -83,7 +83,8 @@ class WeatherDataGapfiller(QMainWindow):
             'Force the reloading of the weather data files')
         self.btn_refresh_staList.setIconSize(get_iconsize('small'))
         self.btn_refresh_staList.setAutoRaise(True)
-        self.btn_refresh_staList.clicked.connect(self.load_data_dir_content)
+        self.btn_refresh_staList.clicked.connect(
+            lambda: self.load_data_dir_content(force_reload=True))
 
         self.btn_delete_data = QToolButton()
         self.btn_delete_data.setIcon(get_icon('delete_data'))
@@ -366,7 +367,7 @@ class WeatherDataGapfiller(QMainWindow):
             self.target_station_info.setText(target_info)
 
     # ---- Load Data
-    def load_data_dir_content(self):
+    def load_data_dir_content(self, force_reload=False):
         """
         Load weater data from valid files contained in the working directory.
         """
@@ -374,7 +375,7 @@ class WeatherDataGapfiller(QMainWindow):
         self._loading_data_inprogress = True
         self.left_panel.setEnabled(False)
         self.right_panel.setEnabled(False)
-        self.progressbar.show()
+            force_reload=force_reload,
 
         self.corrcoeff_textedit.setText('')
         self.target_station_info.setText('')

--- a/cdprep/gapfill_data/gapfill_weather_gui.py
+++ b/cdprep/gapfill_data/gapfill_weather_gui.py
@@ -375,13 +375,13 @@ class WeatherDataGapfiller(QMainWindow):
         self._loading_data_inprogress = True
         self.left_panel.setEnabled(False)
         self.right_panel.setEnabled(False)
-            force_reload=force_reload,
 
         self.corrcoeff_textedit.setText('')
         self.target_station_info.setText('')
         self.target_station.clear()
 
         self.gapfill_manager.load_data(
+            force_reload=force_reload,
             callback=self._handle_data_dir_content_loaded)
 
     def _handle_data_dir_content_loaded(self):


### PR DESCRIPTION
Currently, every time that we open the app, the entire set of data is loaded from the csv every time. This can be very slow when there is a lot of csv files in the working directory.

The solution is to cache the loaded/formatted data in a binary file and load the data from there whenever it is possible.