### PR TITLE
PR: Cache correlation coefficients

### DIFF
--- a/cdprep/gapfill_data/gapfill_weather_gui.py
+++ b/cdprep/gapfill_data/gapfill_weather_gui.py
@@ -338,6 +338,7 @@ class WeatherDataGapfiller(QMainWindow):
                 self._pending_corrcoeff_update = station_id
             else:
                 self._corrcoeff_update_inprogress = True
+                self.corrcoeff_textedit.setText('')
                 self.gapfill_manager.set_target_station(
                     station_id, callback=self._handle_corrcoeff_updated)
 


### PR DESCRIPTION
Currently, the correlation coefficient are calculated for ALL stations every time the target station is changed.

This PR improve this by caching the correlation coefficients in memory and on the disk, so that they are calculated only once. The correlation coefficient are recalculated only when a change is made to the dataset.